### PR TITLE
Add redirect to parser and executor

### DIFF
--- a/exec/exec.c
+++ b/exec/exec.c
@@ -6,26 +6,52 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 22:19:41 by lray              #+#    #+#             */
-/*   Updated: 2023/08/14 01:36:20 by lray             ###   ########.fr       */
+/*   Updated: 2023/08/18 17:39:11 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
+static int	open_file(char *path, int flag, int file_perm);
 static t_dynarrstr	*exec_make_argv(t_dyntree *root);
 static int	exec_find_cmd(t_dynarrstr *dynarr);
 static int	is_cmd(char *path);
 
 /*
 	TODO:
-		. Check PATH to find cmd
+		THIS FILE IS HORRIBLE BUT IT WORKS FINE.
+		IT'S MUST BE CLEANED BEFORE IT BECOMES A MONSTER.
 */
 
 int	exec(t_dyntree *root)
 {
 	t_dynarrstr	*dynarr;
 	pid_t	pid;
+	int		fd_in;
+	int		fd_out;
+	int		i;
 
+	fd_in = STDIN_FILENO;
+	fd_out = STDOUT_FILENO;
+	i = 0;
+	while (i < (int)root->numChildren)
+	{	if (root->children[i]->type == TK_REDIRECTION)
+		{
+			if (ft_strncmp(root->children[i]->value, "<", 1) == 0)
+			{
+				fd_in = open_file(root->children[i]->children[0]->value, O_RDONLY, 0);
+				if (fd_in == -1)
+					return (0);
+			}
+			else if (ft_strncmp(root->children[i]->value, ">", 1) == 0)
+			{
+				fd_out = open_file(root->children[i]->children[0]->value, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+				if (fd_out == -1)
+					return (0);
+			}
+		}
+		i++;
+	}
 	dynarr = exec_make_argv(root);
 	if (dynarr == NULL)
 		return (0);
@@ -43,11 +69,35 @@ int	exec(t_dyntree *root)
 		return (0);
 	}
 	if (pid == 0)
+	{
+		dup2(fd_in, STDIN_FILENO);
+		dup2(fd_out, STDOUT_FILENO);
 		execve(dynarr->array[0], dynarr->array, NULL);
+	}
 	else
 		wait(NULL);
 	dynarrstr_free(dynarr);
+	if (fd_in != STDIN_FILENO)
+		close(fd_in);
+	if (fd_out != STDOUT_FILENO)
+		close(fd_out);
 	return (1);
+}
+
+static int	open_file(char *path, int flag, int file_perm)
+{
+	int	fd;
+
+	if (file_perm == 0)
+		fd = open(path, flag);
+	else
+		fd = open(path, flag, file_perm);
+	if (fd == -1)
+	{
+		perror("miniShrek");
+		return (-1);
+	}
+	return (fd);
 }
 
 static t_dynarrstr	*exec_make_argv(t_dyntree *root)
@@ -68,8 +118,11 @@ static t_dynarrstr	*exec_make_argv(t_dyntree *root)
 			i = 0;
 			while (i < root->numChildren)
 			{
-				if (dynarrstr_add(dynarr, root->children[i]->value) == 0)
-					return (NULL);
+				if (root->children[i]->type == TK_ARGUMENT)
+				{
+					if (dynarrstr_add(dynarr, root->children[i]->value) == 0)
+						return (NULL);
+				}
 				i++;
 			}
 		}

--- a/lexer/dyntklist.c
+++ b/lexer/dyntklist.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/11 21:36:38 by lray              #+#    #+#             */
-/*   Updated: 2023/08/14 02:10:29 by lray             ###   ########.fr       */
+/*   Updated: 2023/08/18 13:17:54 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,11 +50,35 @@ int	dyntklist_add(t_dyntklist *tklist, int type, char *value)
 	return (1);
 }
 
+int dyntklist_delone(t_dyntklist *tklist, int id)
+{
+	int	i;
+
+	if (tklist == NULL || id < 0 || id >= (int)tklist->size)
+		return (0);
+	token_free(tklist->array[id]);
+	i = id;
+	while (i < (int)tklist->size - 1)
+	{
+		tklist->array[i] = tklist->array[i + 1];
+		i++;
+	}
+	tklist->size--;
+	tklist->array = ft_realloc(tklist->array, sizeof(t_token) * (tklist->size + 1), sizeof(t_token) * tklist->size);
+	if (tklist->array == NULL)
+	{
+		ft_puterror("Realloc failed");
+		return (0);
+	}
+	tklist->array[tklist->size] = NULL;
+	return (1);
+}
+
 void	dyntklist_show(t_dyntklist *tklist)
 {
 	int	i;
 
-	if (tklist != NULL)
+	if (tklist != NULL && tklist->array)
 	{
 		i = 0;
 		printf("tklist->size : %ld\n", tklist->size);

--- a/lexer/dyntklist.c
+++ b/lexer/dyntklist.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/11 21:36:38 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 13:17:54 by lray             ###   ########.fr       */
+/*   Updated: 2023/08/18 14:48:37 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,7 +64,8 @@ int dyntklist_delone(t_dyntklist *tklist, int id)
 		i++;
 	}
 	tklist->size--;
-	tklist->array = ft_realloc(tklist->array, sizeof(t_token) * (tklist->size + 1), sizeof(t_token) * tklist->size);
+	if (tklist->size > 0)
+		tklist->array = ft_realloc(tklist->array, sizeof(t_token) * (tklist->size + 1), sizeof(t_token) * tklist->size);
 	if (tklist->array == NULL)
 	{
 		ft_puterror("Realloc failed");

--- a/lexer/dyntklist.h
+++ b/lexer/dyntklist.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/11 21:36:45 by lray              #+#    #+#             */
-/*   Updated: 2023/08/11 23:27:19 by lray             ###   ########.fr       */
+/*   Updated: 2023/08/18 13:24:32 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -20,8 +20,9 @@ typedef struct s_dyntklist
 }	t_dyntklist;
 
 t_dyntklist	*dyntklist_init(t_dyntklist *tklist);
-int	dyntklist_add(t_dyntklist *tklist, int type, char *value);
-void	dyntklist_show(t_dyntklist *tklist);
-void	dyntklist_free(t_dyntklist *tklist);
+int			dyntklist_add(t_dyntklist *tklist, int type, char *value);
+void		dyntklist_show(t_dyntklist *tklist);
+int			dyntklist_delone(t_dyntklist *tklist, int id);
+void		dyntklist_free(t_dyntklist *tklist);
 
 #endif

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -6,28 +6,86 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/10 13:29:53 by lray              #+#    #+#             */
-/*   Updated: 2023/08/14 01:36:02 by lray             ###   ########.fr       */
+/*   Updated: 2023/08/18 16:16:07 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
+static t_dyntree	*exctract_root(t_dyntklist *tklist);
+static int			has_token_type(t_dyntklist *tklist, int token_type);
+
 t_dyntree	*parser(t_dyntklist *tklist)
 {
-	t_dyntree	*tree;
+	t_dyntree	*root;
+	int			i;
+	int			num_children;
+
+	root = NULL;
+	root = exctract_root(tklist);
+	num_children = 0;
+	i = 0;
+	while (i < (int)tklist->size)
+	{
+		dyntree_add(root, dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
+		if (tklist->array[i]->type == TK_REDIRECTION)
+		{
+			i++;
+			if (tklist->array[i] != NULL)
+			{
+				num_children = (int)root->numChildren - 1;
+				dyntree_add(root->children[num_children], dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
+				i++;
+			}
+			else
+			{
+				ft_puterror("Error when building tree\n");
+			}
+		}
+		else
+		{
+			i++;
+		}
+	}
+	return (root);
+}
+
+static t_dyntree	*exctract_root(t_dyntklist *tklist)
+{
+	t_dyntree	*root;
 	int			i;
 
-	tree = dyntree_new(tklist->array[0]->type, tklist->array[0]->value);
-	if (tree == NULL)
-		return (NULL);
-	if (tklist->size < 1)
-		return (tree);
-	i = 1;
+	root = NULL;
+	i =  0;
+	if (has_token_type(tklist, TK_COMMAND))
+	{
+		while (tklist->array[i]->type != TK_COMMAND)
+			i++;
+		root = dyntree_new(tklist->array[i]->type, tklist->array[i]->value);
+		dyntklist_delone(tklist, i);
+	}
+	else if (has_token_type(tklist, TK_REDIRECTION))
+	{
+		while (tklist->array[i]->type != TK_REDIRECTION)
+			i++;
+		root = dyntree_new(tklist->array[i]->type, tklist->array[i]->value);
+		dyntklist_delone(tklist, i);
+	}
+	return (root);
+}
+
+static int	has_token_type(t_dyntklist *tklist, int token_type)
+{
+	int	i;
+
+	if (tklist == NULL || tklist->array == NULL || token_type < 0)
+		return (0);
+	i = 0;
 	while (tklist->array[i])
 	{
-		if (dyntree_add(tree, dyntree_new(tklist->array[i]->type, tklist->array[i]->value)) == 0)
-			return (NULL);
+		if (tklist->array[i]->type == token_type)
+			return (1);
 		i++;
 	}
-	return (tree);
+	return (0);
 }


### PR DESCRIPTION
This PR adapts the parser and executor for the `TK_REDIRECTION` token.

**Parser**
In order to take `TK_REDIRECTION` into account, I had to completely change the tree creation algorithm. Now, the algorithm looks for the new head of the tree, choosing the head according to these priorities:

- If there is a token of type `TK_COMMAND`, it will become the head and will be removed from the list of tokens.
- Otherwise, if there is a token of type `TK_REDIRECTION`, it will become the head and will be removed from the token list.
- Otherwise, Error (I'm sure you'll have to change this, as I haven't quite figured out how Bash handles quoting, but it may have something to do with the backslash). 

In order to remove the head once it's been found, I've added the `dyntklist_delone()` function.

**Executor**
Now that the tree has changed, I had to adapt the executor.
`The exec_make_argv()` function only adds tokens of type `TK_ARGUMENT` to the `argv` of the command to be executed. We don't want any `TK_REDIRECTION` or `TK_FILES` in `argv`.

The algorithm works like this: it scans all the children, and if the child is a `TK_REDIRECTION`, it looks to see if it's a `<` or a `>`. If it's a `<`, it opens the file `readonly`, so if the file doesn't exist, an error will be raised. If it's a `>`, it opens the file in `write-only` mode, so if the file doesn't exist, it's created, and if it does exist, its contents are overwritten.

At the moment, the `exec.c` file is a huge, nameless mess. I've pushed it this way because it's functional, and I plan to clean it up this weekend.

This is my first PR with big conflicts, I hope the merge will go well...