### PR TITLE
Syntax with redirection seems to work well. But its a big mess

### DIFF
--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:56 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 01:34:33 by lray             ###   ########.fr       */
+/*   Updated: 2023/08/18 22:17:10 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,7 +72,7 @@ static t_dyntklist *tokenize(char **splitted_input)
 	while (is_redirect(splitted_input[i]))
 	{
 		dyntklist_add(tklist, TK_REDIRECTION, splitted_input[i++]);
-		if (splitted_input[i] != NULL)
+		if (splitted_input[i] != NULL && is_redirect(splitted_input[i]) == 0)
 			dyntklist_add(tklist, TK_FILE, splitted_input[i++]);
 		else
 		{
@@ -90,7 +90,7 @@ static t_dyntklist *tokenize(char **splitted_input)
 		if (is_redirect(splitted_input[i]))
 		{
 			dyntklist_add(tklist, TK_REDIRECTION, splitted_input[i++]);
-			if (splitted_input[i] != NULL)
+			if (splitted_input[i] != NULL && is_redirect(splitted_input[i]) == 0)
 				dyntklist_add(tklist, TK_FILE, splitted_input[i++]);
 			else
 			{


### PR DESCRIPTION
In order to manage trees composed solely of TK_REDIRECTION and TK_FILES, I've split the algorithm in two. 
At first, I check whether the head is a redirection, and if so, I process the strings from TL_REDIRECTION and TK_FILES.
If not, I apply the same algo as before this PR.

I really need to clean up this code because it's become really ugly and huge. I'm going to redo it all this weekend.