### PR TITLE
Lexer refactore fore pipes

### DIFF
--- a/lexer/dyntklist.c
+++ b/lexer/dyntklist.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/11 21:36:38 by lray              #+#    #+#             */
-/*   Updated: 2023/09/05 11:02:10 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/05 15:29:37 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -96,7 +96,17 @@ void	dyntklist_show(t_dyntklist *tklist)
 		printf("tklist->size : %ld\n", tklist->size);
 		while (tklist->array[i])
 		{
-			printf("tklist->array[%d]->type : %d\n", i, tklist->array[i]->type);
+			printf("tklist->array[%d]->type : ", i);
+			if (tklist->array[i]->type == 0)
+				printf("TK_COMMAND\n");
+			else if (tklist->array[i]->type == 1)
+				printf("TK_ARGUMENT\n");
+			else if (tklist->array[i]->type == 2)
+				printf("TK_FILE\n");
+			else if (tklist->array[i]->type == 3)
+				printf("TK_REDIRECTION\n");
+			else if (tklist->array[i]->type == 4)
+				printf("TK_PIPE\n");
 			printf("tklist->array[%d]->value : %s\n", i, tklist->array[i]->value);
 			i++;
 		}

--- a/lexer/dyntklist.c
+++ b/lexer/dyntklist.c
@@ -6,11 +6,16 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/11 21:36:38 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 14:48:37 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/05 11:02:10 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
+
+/*
+	TODO:
+		- Il faut que je traite les erreurs ici et pas plus tard
+*/
 
 t_dyntklist	*dyntklist_init(t_dyntklist *tklist)
 {
@@ -18,10 +23,16 @@ t_dyntklist	*dyntklist_init(t_dyntklist *tklist)
 	{
 		tklist = malloc(sizeof(t_dyntklist) * 1);
 		if (tklist == NULL)
+		{
+			ft_puterror("Malloc failed");
 			return (NULL);
+		}
 		tklist->array = malloc(sizeof(t_token) * 1);
 		if (tklist->array == NULL)
+		{
+			ft_puterror("Malloc failed");
 			return (NULL);
+		}
 		tklist->array[0] = NULL;
 		tklist->size = 0;
 	}

--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:56 by lray              #+#    #+#             */
-/*   Updated: 2023/09/05 11:02:25 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/05 15:41:29 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -56,48 +56,58 @@ static char	**split_input(char *input)
 	return (splitted_input);
 }
 
+
 static t_dyntklist *tokenize(char **splitted_input)
 {
-	t_dyntklist	*tklist;
+	t_dyntklist *tklist;
 	int			i;
 
 	tklist = NULL;
+	if (is_pipe(splitted_input[0]))
+	{
+		ft_puterror("Syntax error");
+		return (NULL);
+	}
 	tklist = dyntklist_init(tklist);
 	if (tklist == NULL)
 		return (NULL);
 	i = 0;
-	while (is_redirect(splitted_input[i]))
-	{
-		dyntklist_add(tklist, TK_REDIRECTION, splitted_input[i++]);
-		if (splitted_input[i] != NULL && is_redirect(splitted_input[i]) == 0)
-			dyntklist_add(tklist, TK_FILE, splitted_input[i++]);
-		else
-		{
-			ft_puterror("syntax error");
-			dyntklist_free(tklist);
-			return (NULL);
-		}
-	}
-	if (splitted_input[i] == NULL)
-		return (tklist);
-	dyntklist_add(tklist, TK_COMMAND, splitted_input[i]);
-	i++;
 	while (splitted_input[i])
 	{
 		if (is_redirect(splitted_input[i]))
 		{
-			dyntklist_add(tklist, TK_REDIRECTION, splitted_input[i++]);
-			if (splitted_input[i] != NULL && is_redirect(splitted_input[i]) == 0)
-				dyntklist_add(tklist, TK_FILE, splitted_input[i++]);
+			if (splitted_input[i + 1] != NULL)
+			{
+				dyntklist_add(tklist, TK_REDIRECTION, splitted_input[i]);
+				i++;
+				dyntklist_add(tklist, TK_FILE, splitted_input[i]);
+				i++;
+				continue ;
+			}
 			else
 			{
-				ft_puterror("syntax error");
-				dyntklist_free(tklist);
+				ft_puterror("Syntax error");
 				return (NULL);
 			}
 		}
+		else if (is_pipe(splitted_input[i]))
+		{
+			dyntklist_add(tklist, TK_PIPE, "|");
+			i++;
+			continue ;
+		}
 		else
-			dyntklist_add(tklist, TK_ARGUMENT, splitted_input[i++]);
+		{
+			dyntklist_add(tklist, TK_COMMAND, splitted_input[i]);
+			i++;
+			while (splitted_input[i] && is_redirect(splitted_input[i]) == 0 && is_pipe(splitted_input[i]) == 0)
+			{
+				dyntklist_add(tklist, TK_ARGUMENT, splitted_input[i]);
+				i++;
+			}
+			continue ;
+		}
 	}
 	return (tklist);
 }
+

--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:56 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 22:17:10 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/05 11:02:25 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -64,10 +64,7 @@ static t_dyntklist *tokenize(char **splitted_input)
 	tklist = NULL;
 	tklist = dyntklist_init(tklist);
 	if (tklist == NULL)
-	{
-		ft_puterror("Token list initialization failed");
 		return (NULL);
-	}
 	i = 0;
 	while (is_redirect(splitted_input[i]))
 	{

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:51 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 01:33:13 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/05 15:04:24 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,5 +18,6 @@ char		*trim_and_condense_string(const char *input);
 
 int	is_only_space(char *input);
 int	is_redirect(char *token);
+int is_pipe(char *token);
 
 #endif

--- a/lexer/lexer_utils.c
+++ b/lexer/lexer_utils.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/18 01:31:05 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 01:33:20 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/05 15:07:11 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -35,6 +35,12 @@ int	is_redirect(char *token)
 	if (token && ft_strlen(token) == 1 && \
 		(ft_strncmp(token, "<", 1) == 0 || ft_strncmp(token, ">", 1) == 0))
 		return (1);
-	else
-		return (0);
+	return (0);
+}
+
+int is_pipe(char *token)
+{
+	if (token && ft_strlen(token) == 1 && ft_strncmp(token, "|", 1) == 0)
+		return (1);
+	return (0);
 }


### PR DESCRIPTION
The aim of this PR is to adapt the lexer to the pipes.

Most of the changes are to be found in the algorithm that determines the type of token. The algorithm now understands pipes, handles syntax errors and is cleaner and more readable than the previous version.

In order for the new algorithm to do its job, I needed to add the `is_pipe()` function to the lexer's utils file. This function takes a token, checks that it's one character long and that character is |. If so, it returns 1, otherwise 0.

Finally, I modified the `dyntklist_show()` function so that it displays the token type as text.