### PR TITLE
Parser refactore for pipe

### DIFF
--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:56 by lray              #+#    #+#             */
-/*   Updated: 2023/09/05 15:41:29 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/15 18:37:01 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -92,6 +92,11 @@ static t_dyntklist *tokenize(char **splitted_input)
 		}
 		else if (is_pipe(splitted_input[i]))
 		{
+			if (splitted_input[i + 1] == NULL || is_pipe(splitted_input[i + 1]) == 1)
+			{
+				ft_puterror("Syntax error");
+				return (NULL);
+			}
 			dyntklist_add(tklist, TK_PIPE, "|");
 			i++;
 			continue ;

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 19:08:50 by lray              #+#    #+#             */
-/*   Updated: 2023/08/19 12:40:31 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/15 18:36:37 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -15,15 +15,9 @@
 static void	free_line(char *input, t_dyntklist *tklist, t_dyntree *tree);
 
 /*
-	/!\ /!\ /!\
-	Il ne faut jamais oublier de set input, tklist et tree
-		a NULL au début de la main loop.
-	Si il ne sont pas set de la sorte, n'importe quelle commande
-		après une commande inconnue déclanche un segfault.
-	/!\ /!\ /!\
-
 	FIXME:
 		- Lorsque nous entrons un ou des '/', ne reagit pas comme Bash.
+		- Il faut que lorsque la commande ne soit pas trouvée, un message s'affiche
 */
 
 int	main(void)
@@ -56,11 +50,7 @@ int	main(void)
 			free_line(input, tklist, tree);
 			continue ;
 		}
-		if (exec(tree) == 0)
-		{
-			free_line(input, tklist, tree);
-			continue ;
-		}
+		exec(tree);
 		free_line(input, tklist, tree);
 	}
 	clear_history();

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/10 13:29:53 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 16:16:07 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/15 18:35:57 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,38 +14,42 @@
 
 static t_dyntree	*exctract_root(t_dyntklist *tklist);
 static int			has_token_type(t_dyntklist *tklist, int token_type);
+static int	add_to_cmd(t_dyntklist *tklist, t_dyntree *root, int pos);
+static t_dyntree	*add_cmd_to_root(t_dyntklist *tklist, t_dyntree *root);
 
 t_dyntree	*parser(t_dyntklist *tklist)
 {
 	t_dyntree	*root;
-	int			i;
-	int			num_children;
+	size_t		i;
+	int			last_pipe;
 
 	root = NULL;
 	root = exctract_root(tklist);
-	num_children = 0;
-	i = 0;
-	while (i < (int)tklist->size)
+
+	if (root->type == TK_COMMAND || root->type == TK_REDIRECTION)
 	{
-		dyntree_add(root, dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
-		if (tklist->array[i]->type == TK_REDIRECTION)
+		add_to_cmd(tklist, root, 0);
+	}
+	else if (root->type == TK_PIPE)
+	{
+		add_cmd_to_root(tklist, root);
+		i = 0;
+		last_pipe = 0;
+		while (i < root->numChildren)
 		{
-			i++;
-			if (tklist->array[i] != NULL)
+			last_pipe = add_to_cmd(tklist, root->children[i], last_pipe) + 1;
+			if (last_pipe == -1)
 			{
-				num_children = (int)root->numChildren - 1;
-				dyntree_add(root->children[num_children], dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
-				i++;
+				printf("ERREUR\n");
+				break ;
 			}
-			else
-			{
-				ft_puterror("Error when building tree\n");
-			}
+			++i;
 		}
-		else
-		{
-			i++;
-		}
+	}
+	else
+	{
+		ft_puterror("Unknow root");
+		return (NULL);
 	}
 	return (root);
 }
@@ -57,19 +61,23 @@ static t_dyntree	*exctract_root(t_dyntklist *tklist)
 
 	root = NULL;
 	i =  0;
-	if (has_token_type(tklist, TK_COMMAND))
+	if (has_token_type(tklist, TK_PIPE))
+	{
+		while (tklist->array[i]->type != TK_PIPE)
+			i++;
+		root = dyntree_new(TK_PIPE, "|");
+	}
+	else if (has_token_type(tklist, TK_COMMAND))
 	{
 		while (tklist->array[i]->type != TK_COMMAND)
 			i++;
 		root = dyntree_new(tklist->array[i]->type, tklist->array[i]->value);
-		dyntklist_delone(tklist, i);
 	}
 	else if (has_token_type(tklist, TK_REDIRECTION))
 	{
 		while (tklist->array[i]->type != TK_REDIRECTION)
 			i++;
 		root = dyntree_new(tklist->array[i]->type, tklist->array[i]->value);
-		dyntklist_delone(tklist, i);
 	}
 	return (root);
 }
@@ -88,4 +96,62 @@ static int	has_token_type(t_dyntklist *tklist, int token_type)
 		i++;
 	}
 	return (0);
+}
+
+static int	add_to_cmd(t_dyntklist *tklist, t_dyntree *root, int pos)
+{
+	int			i;
+	int			num_children;
+
+	num_children = 0;
+	i = pos;
+	if (pos > (int)tklist->size)
+		return (-1);
+	if (root->type == TK_REDIRECTION)
+		++i;
+	while (i < (int)tklist->size && tklist->array[i]->type != TK_PIPE)
+	{
+		if (tklist->array[i]->type == TK_PIPE)
+			return (i);
+		if (tklist->array[i]->type == TK_COMMAND)
+		{
+			++i;
+			continue ;
+		}
+		dyntree_add(root, dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
+		if (tklist->array[i]->type == TK_REDIRECTION)
+		{
+			i++;
+			if (tklist->array[i] != NULL)
+			{
+				num_children = (int)root->numChildren - 1;
+				dyntree_add(root->children[num_children], dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
+				i++;
+			}
+			else
+			{
+				ft_puterror("Error when building tree\n");
+				return (-1);
+			}
+		}
+		else
+		{
+			++i;
+		}
+	}
+	return (i);
+}
+
+static t_dyntree	*add_cmd_to_root(t_dyntklist *tklist, t_dyntree *root)
+{
+	size_t	i;
+
+	i = 0;
+	while (i < tklist->size)
+	{
+		if (tklist->array[i]->type == TK_COMMAND)
+			dyntree_add(root, dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
+		i++;
+	}
+	return (root);
 }


### PR DESCRIPTION
The parser can now create trees with a pipe as root!

Thanks to this PR, *MiniShrek* can now execute commands chained by pipes.

To do this, I've adapted the old parser. In fact, the old parser has become the `add_to_cmd()` function.

The purpose of this function is to add the children of a command. This is exactly what the old parser did before taking pipes into account. When there were no pipes, the child was necessarily a command/redirector.

To take pipes into account, I've added the `add_cmd_to_root()` function. This function is called when the root of the received tree is a pipe. Its purpose is to browse the *tklist* and add these commands as children of the root.

Finally, here's how the `parser()` function works again:
- It extracts the tree root.
- If the root is a command/redirector, it calls the `add_to_cmd()` function to build the tree.
- If the root is a pipe, it calls the `add_cmd_to_root()` function to create the first part of the tree, it traverses all the root's children (the commands) and for each command, it calls the `add_to_cmd()` function to finish building the tree.

Finally, I fixed a bug in *lexer.c* that caused the program to crash when the command entered ended in a pipe, or if the command included two consecutive pipes.
I've also updated the comments in *main.c*.
