### PR TITLE
New lexer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ SRCS 		:= \
 OBJS		:= $(SRCS:.c=.o)
 
 CC 			:= gcc
-CFLAGS		:= -Wall -Wextra -Werror -std=gnu89 -g
+CFLAGS		:= -Wall -Wextra -Werror -std=gnu89 -fsanitize=address -static-libasan -g
 CPPFLAGS	:= -Ireadline/include/readline/ -lreadline -Lreadline/lib -Ilibft -Iprompt -Ilexer
 
 LIBS		:= \

--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:56 by lray              #+#    #+#             */
-/*   Updated: 2023/09/23 17:19:28 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/23 17:30:51 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,6 @@ t_dyntklist	*lexer(char *input)
 	tklist = dyntklist_init(tklist);
 	in_cmd = 0;
 	i = 0;
-	skip_space(input, &i);
 	while (input[i] != '\0')
 	{
 		skip_space(input, &i);

--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,113 +6,211 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:56 by lray              #+#    #+#             */
-/*   Updated: 2023/09/15 18:37:01 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/23 17:19:28 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-static t_dyntklist	*lexer_run(char *input);
-static char	**split_input(char *input);
-static t_dyntklist *tokenize(char **splitted_input);
+static void	skip_space(char *input, int *i);
+static int	add_redirect(char *input, t_dyntklist *tklist, int *i);
+static int	add_file(char *input, t_dyntklist *tklist, int *i);
+static int	add_cmd(char *input, t_dyntklist *tklist, int *i);
+static int	add_arg(char *input, t_dyntklist *tklist, int *i);
 
 t_dyntklist	*lexer(char *input)
 {
-	char		*cleaned_input;
+	int i;
+	int in_cmd;
 	t_dyntklist	*tklist;
-
-	if (is_only_space(input) == 0)
-		return (NULL);
-	cleaned_input = trim_and_condense_string(input);
-	// TODO: get error
-	tklist = lexer_run(cleaned_input);
-	free(cleaned_input);
-	return (tklist);
-}
-
-static t_dyntklist	*lexer_run(char *input)
-{
-	char		**splitted_input;
-	t_dyntklist	*tklist;
-
-	splitted_input = split_input(input);
-	if (splitted_input == NULL)
-		return (NULL);
-	tklist = tokenize(splitted_input);
-	ft_freesplit(splitted_input);
-	return (tklist);
-}
-
-static char	**split_input(char *input)
-{
-	char		**splitted_input;
-
-	splitted_input = ft_split(input, ' ');
-	if (splitted_input == NULL)
-	{
-		perror("Split failed");
-		return (NULL);
-	}
-	return (splitted_input);
-}
-
-
-static t_dyntklist *tokenize(char **splitted_input)
-{
-	t_dyntklist *tklist;
-	int			i;
 
 	tklist = NULL;
-	if (is_pipe(splitted_input[0]))
-	{
-		ft_puterror("Syntax error");
-		return (NULL);
-	}
 	tklist = dyntklist_init(tklist);
-	if (tklist == NULL)
-		return (NULL);
+	in_cmd = 0;
 	i = 0;
-	while (splitted_input[i])
+	skip_space(input, &i);
+	while (input[i] != '\0')
 	{
-		if (is_redirect(splitted_input[i]))
+		skip_space(input, &i);
+		if (input[i] == '\0')
+			break ;
+		if (is_redirect(input[i]))
 		{
-			if (splitted_input[i + 1] != NULL)
+			if (is_pipe(input[i]))
 			{
-				dyntklist_add(tklist, TK_REDIRECTION, splitted_input[i]);
-				i++;
-				dyntklist_add(tklist, TK_FILE, splitted_input[i]);
-				i++;
-				continue ;
+				dyntklist_add(tklist, TK_PIPE, "|");
+				in_cmd = 0;
 			}
 			else
 			{
-				ft_puterror("Syntax error");
-				return (NULL);
+				if (add_redirect(input, tklist, &i) == 0)
+					return (NULL);
+				skip_space(input, &i);
+				if (add_file(input, tklist, &i) == 0)
+					return (NULL);
 			}
 		}
-		else if (is_pipe(splitted_input[i]))
+		else if (in_cmd == 0)
 		{
-			if (splitted_input[i + 1] == NULL || is_pipe(splitted_input[i + 1]) == 1)
-			{
-				ft_puterror("Syntax error");
+			if (add_cmd(input, tklist, &i) == 0)
 				return (NULL);
-			}
-			dyntklist_add(tklist, TK_PIPE, "|");
-			i++;
-			continue ;
+			in_cmd = 1;
 		}
 		else
 		{
-			dyntklist_add(tklist, TK_COMMAND, splitted_input[i]);
-			i++;
-			while (splitted_input[i] && is_redirect(splitted_input[i]) == 0 && is_pipe(splitted_input[i]) == 0)
-			{
-				dyntklist_add(tklist, TK_ARGUMENT, splitted_input[i]);
-				i++;
-			}
-			continue ;
+			if (add_arg(input, tklist, &i) == 0)
+				return (NULL);
 		}
+		i++;
 	}
 	return (tklist);
 }
 
+static void	skip_space(char *input, int *i)
+{
+	while (input[*i] != '\0' && input[*i] == ' ')
+		(*i)++;
+}
+
+static int	add_redirect(char *input, t_dyntklist *tklist, int *i)
+{
+	char *value;
+
+	if (input[(*i) + 1] == '\0')
+	{
+		ft_puterror("Syntax error");
+		return (0);
+	}
+	else if (input[*i] != input[(*i) + 1] && is_redirect(input[(*i) + 1]))
+	{
+		ft_puterror("Syntax error");
+		return (0);
+	}
+	else if (is_redirect(input[(*i) + 2]))
+	{
+		ft_puterror("Syntax error");
+		return (0);
+	}
+	else if (input[*i] == input[(*i) + 1])
+	{
+		value = malloc(sizeof(char) * 3);
+		if (value == NULL)
+		{
+			ft_puterror("Malloc failed");
+			return (0);
+		}
+		value[0] = input[*i];
+		value[1] = input[*i];
+		value[2] = '\0';
+		dyntklist_add(tklist, TK_REDIRECTION, value);
+		free(value);
+		(*i) += 2;
+		return (1);
+	}
+	else
+	{
+		value = malloc(sizeof(char) * 2);
+		if (value == NULL)
+		{
+			ft_puterror("Malloc failed");
+			return (0);
+		}
+		value[0] = input[*i];
+		value[1] = '\0';
+		dyntklist_add(tklist, TK_REDIRECTION, value);
+		free(value);
+		(*i)++;
+		return (1);
+	}
+}
+
+static int	add_file(char *input, t_dyntklist *tklist, int *i)
+{
+	char	*value;
+	size_t	value_len;
+
+	value = NULL;
+	value = malloc(sizeof(char) * 1);
+	if (value == NULL)
+	{
+		ft_puterror("Malloc failed");
+		return (0);
+	}
+	value[0] = '\0';
+	while (input[*i] != '\0' && input[*i] != ' ' && !is_redirect(input[*i]))
+	{
+		value_len = ft_strlen(value) + 1;
+		value = ft_realloc(value, value_len * sizeof(char), value_len + 1 * sizeof(char));
+		if (value == NULL)
+		{
+			ft_puterror("Realloc failed");
+			return (0);
+		}
+		ft_strlcat(value, &input[*i], value_len + 1);
+		(*i)++;
+	}
+	(*i)--;
+	dyntklist_add(tklist, TK_FILE, value);
+	free(value);
+	return (1);
+}
+
+static int	add_cmd(char *input, t_dyntklist *tklist, int *i)
+{
+	char	*value;
+	size_t	value_len;
+
+	value = malloc(sizeof(char) * 1);
+	if (value == NULL)
+	{
+		ft_puterror("Malloc failed");
+		return (0);
+	}
+	value[0] = '\0';
+	while (input[*i] != '\0' && input[*i] != ' ' && !is_redirect(input[*i]))
+	{
+		value_len = ft_strlen(value) + 1;
+		value = ft_realloc(value, value_len * sizeof(char), value_len + 1 * sizeof(char));
+		if (value == NULL)
+		{
+			ft_puterror("Realloc failed");
+			return (0);
+		}
+		ft_strlcat(value, &input[*i], value_len + 1);
+		(*i)++;
+	}
+	(*i)--;
+	dyntklist_add(tklist, TK_COMMAND, value);
+	free(value);
+	return (1);
+}
+
+static int	add_arg(char *input, t_dyntklist *tklist, int *i)
+{
+	char	*value;
+	size_t	value_len;
+
+	value = malloc(sizeof(char) * 1);
+	if (value == NULL)
+	{
+		ft_puterror("Malloc failed");
+		return (0);
+	}
+	*value = '\0';
+	while (input[*i] != '\0' && input[*i] != ' ' && !is_redirect(input[*i]))
+	{
+		value_len = ft_strlen(value) + 1;
+		value = ft_realloc(value, value_len * sizeof(char), value_len + 1 * sizeof(char));
+		if (value == NULL)
+		{
+			ft_puterror("Realloc failed");
+			return (0);
+		}
+		ft_strlcat(value, &input[*i], value_len + 1);
+		(*i)++;
+	}
+	(*i)--;
+	dyntklist_add(tklist, TK_ARGUMENT, value);
+	free(value);
+	return (1);
+}

--- a/lexer/lexer.h
+++ b/lexer/lexer.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:51 by lray              #+#    #+#             */
-/*   Updated: 2023/09/05 15:04:24 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/22 17:12:32 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -16,8 +16,7 @@
 t_dyntklist	*lexer(char *input);
 char		*trim_and_condense_string(const char *input);
 
-int	is_only_space(char *input);
-int	is_redirect(char *token);
-int is_pipe(char *token);
+int	is_redirect(char token);
+int	is_pipe(char token);
 
 #endif

--- a/lexer/lexer_utils.c
+++ b/lexer/lexer_utils.c
@@ -6,47 +6,22 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/18 01:31:05 by lray              #+#    #+#             */
-/*   Updated: 2023/09/19 19:00:26 by lray             ###   ########.fr       */
+/*   Updated: 2023/09/22 17:16:33 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-int	is_only_space(char *input)
+int	is_redirect(char token)
 {
-	int	nbr_space;
-	int	i;
-
-	i = 0;
-	nbr_space = 0;
-	while (input[i])
-	{
-		if (input[i] == ' ')
-			nbr_space++;
-		i++;
-	}
-	if (nbr_space == i)
-		return (0);
-	return (1);
-}
-
-int	is_redirect(char *token)
-{
-	if (token)
-	{
-		if (ft_strlen(token) == 1 && ft_strncmp(token, "<", 1) == 0)
-			return (1);
-		else if (ft_strlen(token) == 1 && ft_strncmp(token, ">", 1) == 0)
-			return (1);
-		else if (ft_strlen(token) == 2 && ft_strncmp(token, ">>", 2) == 0)
-			return (1);
-	}
+	if (token == '<' || token == '>' || token == '|')
+		return (1);
 	return (0);
 }
 
-int is_pipe(char *token)
+int	is_pipe(char token)
 {
-	if (token && ft_strlen(token) == 1 && ft_strncmp(token, "|", 1) == 0)
+	if (token == '|')
 		return (1);
 	return (0);
 }


### PR DESCRIPTION
This PR fixes #13

In order to take into account the two redirector syntaxes `<[file]` and `< [file]` and not just the `< [file]` syntax, I had to make a major change to the way the lexer works.

Before, we used to retrieve the input as a string, which we split on the space character. This doesn't work with the new syntax, which must take into account redirectors that are pasted directly to the file name. 

In order to handle spaces, the lexer no longer splits input, but parses it character by character.

This approach is also much easier to read and understand.

Please review and let me know what you think. Don't hesitate to ask me questions if you don't understand how it works.
I've also tested the lexer quite a bit to make sure it's working properly, I've probably missed a lot of tests. **You'll have to test it intensively with all the worst commands you can imagine. This is a very important step, I can't think of everything.**

Bye 