### PR TITLE
Fix issue 27

### DIFF
--- a/expand/expand.c
+++ b/expand/expand.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/27 15:19:55 by lray              #+#    #+#             */
-/*   Updated: 2023/10/02 15:46:08 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/07 18:44:15 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,9 +40,22 @@ static int	valide_tree(t_dyntree *root)
 			return (0);
 		}
 	}
-	if (root->type == TK_COMMAND)
+	else if (root->type == TK_PIPE)
+	{
+		if (root->numChildren < 2)
+		{
+			ft_puterror("ambiguous redirect");
+			return (0);
+		}
+	}
+	else if (root->type == TK_COMMAND)
 	{
 		if (root->value[0] == '\0')
+			return (0);
+	}
+	else if (root->type == TK_REDIRECTION)
+	{
+		if (root->numChildren < 1 || root->children[0]->type != TK_FILE)
 			return (0);
 	}
 	i = 0;

--- a/parser/parser.c
+++ b/parser/parser.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/10 13:29:53 by lray              #+#    #+#             */
-/*   Updated: 2023/09/15 18:35:57 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/07 18:30:45 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -149,7 +149,7 @@ static t_dyntree	*add_cmd_to_root(t_dyntklist *tklist, t_dyntree *root)
 	i = 0;
 	while (i < tklist->size)
 	{
-		if (tklist->array[i]->type == TK_COMMAND)
+		if (tklist->array[i]->type == TK_COMMAND || tklist->array[i]->type == TK_REDIRECTION)
 			dyntree_add(root, dyntree_new(tklist->array[i]->type, tklist->array[i]->value));
 		i++;
 	}


### PR DESCRIPTION
This PR fixes #27

Since I hadn't realized that `Bash` could interpret empty commands (only redirectors and pipes), I hadn't foreseen that the `parser` could create a tree with a pipe as root and how to child something other than commands.

The problem was corrected by changing the condition that dictates whether an element should be added to the root in `add_to_cmd()`. Previously, I only added a child if it was of type `TK_COMMAND` and now, in addition to `TK_COMMAND`, I add `TK_REDIRECTION`.