### PR TITLE
Plugging a leak

### DIFF
--- a/ctx/ctx.c
+++ b/ctx/ctx.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 20:30:19 by lray              #+#    #+#             */
-/*   Updated: 2023/10/07 21:56:57 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/09 13:25:00 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -40,16 +40,27 @@ void	ctx_free(t_ctx *ctx)
 	if (ctx != NULL)
 	{
 		if (ctx->grpvar)
+		{
 			grpvar_free(ctx->grpvar);
+			ctx->grpvar = NULL;
+		}
 		if (ctx->input)
 		{
 			free(ctx->input);
 			ctx->input = NULL;
 		}
 		if (ctx->tklist)
+		{
 			dyntklist_free(ctx->tklist);
+			ctx->tklist = NULL;
+		}
 		if (ctx->tree)
+		{
 			dyntree_free(ctx->tree);
+			ctx->tree = NULL;
+		}
+		free(ctx);
+		ctx = NULL;
 	}
 }
 

--- a/exec/env_node.c
+++ b/exec/env_node.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/21 18:49:07 by lray              #+#    #+#             */
-/*   Updated: 2023/10/05 15:03:45 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/09 14:08:34 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -137,17 +137,14 @@ void	env_node_free(t_env_node *node)
 
 void	env_node_freeall(t_env_node *head)
 {
-	t_env_node	*next;
+	t_env_node	*p_env;
+	t_env_node	*p_next;
 
-	if (head != NULL)
+	p_env = head;
+	while (p_env != NULL)
 	{
-		while (head != NULL)
-		{
-			next = head->next;
-			env_node_free(head);
-			head = next;
-		}
-		free(head);
-		head = NULL;
+		p_next = p_env->next;
+		env_node_free(p_env);
+		p_env = p_next;
 	}
 }

--- a/exec/exec.c
+++ b/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 22:19:41 by lray              #+#    #+#             */
-/*   Updated: 2023/10/07 21:12:30 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/09 14:21:00 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -53,6 +53,7 @@ static	t_env_node	*make_env_list(t_dyntree *root, t_grpvar *grpvar, t_env_node *
 			}
 			i_child++;
 		}
+		pipes_list_free(pipes_list, (int)root->numChildren - 1);
 	}
 	else
 	{
@@ -88,7 +89,8 @@ static	t_env_node	*make_env_node(t_dyntree *root, t_grpvar *grpvar, t_env_node *
 		argv = make_argv(root);
 		if (argv == NULL)
 			return (NULL);
-		last_el->args = argv->array;
+		last_el->args = arrcpy(argv->array, (int)argv->size);
+		dynarrstr_free(argv);
 		last_el->fd_in = get_infd(root);
 		last_el->fd_out = get_outfd(root);
 		last_el->pipe_in = pipe_in;

--- a/exec/pipes_list.c
+++ b/exec/pipes_list.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/21 18:54:30 by lray              #+#    #+#             */
-/*   Updated: 2023/10/05 14:22:28 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/09 14:15:19 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -78,8 +78,6 @@ void	pipes_list_free(int **pipes_list, int num_pipes)
 	i = 0;
 	while (i < num_pipes)
 	{
-		close(pipes_list[i][0]);
-		close(pipes_list[i][1]);
 		free(pipes_list[i]);
 		i++;
 	}

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 19:08:50 by lray              #+#    #+#             */
-/*   Updated: 2023/10/08 13:55:43 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/09 14:17:20 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,8 +21,6 @@ int	main(int argc, char **argv, char **envp)
 	ctx = NULL;
 	ctx = ctx_init(ctx, envp);
 	set_signals(NULL);
-	grpvar_show(ctx->grpvar);
-	printf("\n");
 	while (1)
 	{
 		ctx_free_line(ctx);

--- a/vars/lstvar.c
+++ b/vars/lstvar.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/26 16:11:12 by lray              #+#    #+#             */
-/*   Updated: 2023/10/07 15:12:10 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/09 14:09:57 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -133,6 +133,7 @@ void	lstvar_free(t_lstvar *lstvar)
 				while (i < lstvar->num_elements)
 				{
 					var_free(lstvar->array[i]);
+					lstvar->array[i] = NULL;
 					++i;
 				}
 			}


### PR DESCRIPTION
I found two memory leaks in the `exec`.

The first leak comes from the generation of argv in `make_env_node()`. This function returns a `t_dynarrstr` which is composed of `array` of type `char **`. Before this patch, I passed `t_dynarrstr->array` to the runtime environment and ended up with `env_node_freeall()`. The problem was that `t_dynarrstr` was never free but `t_dynarrstr->array`. To fix this, I generate the `t_dynarrstr`, then copy `t_dynarrstr->array` into `t_env_node->argv`. Finally, I use `dynarrstr_free()` to free the `t_dynarrstr`.

The second leak came from the `t_pipe_list` which is generated when there is more than one command. I used to generate the list and pass the correct pipes from the `t_pipe_list` to each runtime environment. Once each runtime environment was created, I forgot to release the `t_pipes_list`. So I added a call to `pipes_list_free()` to free the memory cleanly.

I took advantage of this PR to review all the functions used to free the memory of our structures and I cleaned them up, added the `= NULL` and made small corrections here and there.

I also removed the display of global variables when initialising `minishell` in the `main.c` file.