### PR TITLE
Adapte expand to quotes

### DIFF
--- a/expand/expand.c
+++ b/expand/expand.c
@@ -6,13 +6,15 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/27 15:19:55 by lray              #+#    #+#             */
-/*   Updated: 2023/10/09 20:49:55 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/13 20:49:26 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
 static int	valide_tree(t_dyntree *root);
+static int	is_quote(char c);
+int	delete_quotes(t_dyntree *root);
 
 int	expand(t_ctx *ctx)
 {
@@ -20,6 +22,7 @@ int	expand(t_ctx *ctx)
 		return (0);
 	if (!replace_var(ctx->tree, ctx->grpvar))
 		return (0);
+	delete_quotes(ctx->tree);
 	if (!valide_tree(ctx->tree))
 		return (0);
 	replace_builtins(ctx->tree, ctx);
@@ -65,4 +68,51 @@ static int	valide_tree(t_dyntree *root)
 			return (0);
 	}
 	return (1);
+}
+
+int	delete_quotes(t_dyntree *root)
+{
+	size_t	i_child;
+	size_t	i_str;
+	char	quote;
+
+	// sa"lu'ca"lut
+	quote = 0;
+	if (root->type == TK_COMMAND || root->type == TK_ARGUMENT || root->type == TK_FILE)
+	{
+		i_str = 0;
+		while (root->value[i_str] != '\0')
+		{
+			if (is_quote(root->value[i_str]))
+			{
+				if (quote == 0)
+				{
+					quote = root->value[i_str];
+					ft_memmove(root->value + i_str, root->value + i_str + 1, ft_strlen(root->value + i_str));
+					--i_str;
+				}
+				else if (root->value[i_str] == quote)
+				{
+					quote = 0;
+					ft_memmove(root->value + i_str, root->value + i_str + 1, ft_strlen(root->value + i_str));
+					--i_str;
+				}
+
+			}
+			++i_str;
+		}
+	}
+	i_child = 0;
+	while (i_child < root->numChildren)
+	{
+		delete_quotes(root->children[i_child++]);
+	}
+	return (1);
+}
+
+static int	is_quote(char c)
+{
+	if (c == '\'' || c == '"')
+		return (1);
+	return (0);
 }


### PR DESCRIPTION
Quotations are finally implemented!

To do this, I had to adapt the existing `expand`. I realised while adding the quotes to the `lexer` that a token could contain several variables and several sets of quotes in the `value` field.  I hadn't thought of this possibility during the previous iteration of the `expand`. So I rewrote the `replace_var()` function to take this logic into account. I've also been able to add quote support for variable interpretation to this new version of `replace_var()`. It's in this function that I check whether the variable to be replaced is in a `'` or not.

Once the variable substitution was in place, I was able to add the `delete_quotes()` function, which passes over each node in the tree in order to remove the quotes. The algorithm is a little more complicated than just deleting quotes, because if, for example, the value of a token is `"'''"`, you have to delete the `"`, but not the `'`.