### PR TITLE
Fix #49

### DIFF
--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 19:13:07 by lray              #+#    #+#             */
-/*   Updated: 2023/10/11 13:47:01 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/14 15:05:02 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -59,5 +59,7 @@ char **arrcpy(char **arr, int size);
 void	ft_puterror(char *msg);
 
 char	*add_char_to_string(char *str, char c);
+
+int		str_is_only_space(char *str);
 
 #endif

--- a/prompt/prompt.c
+++ b/prompt/prompt.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   prompt.c                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mflury <mflury@student.42lausanne.ch>      +#+  +:+       +#+        */
+/*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 19:19:00 by lray              #+#    #+#             */
-/*   Updated: 2023/08/18 00:51:22 by mflury           ###   ########.fr       */
+/*   Updated: 2023/10/14 15:05:48 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -18,6 +18,7 @@ char	*prompt_get(void)
 
 	rl_on_new_line();
 	input = readline("MiniShrek$ ");
-	add_history(input);
+	if (input != NULL && input[0] != '\0' && !str_is_only_space(input))
+		add_history(input);
 	return (input);
 }

--- a/utils.c
+++ b/utils.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 21:58:35 by lray              #+#    #+#             */
-/*   Updated: 2023/09/29 19:38:52 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/14 15:04:37 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -65,4 +65,18 @@ char	*add_char_to_string(char *str, char c)
 	str[len - 1] = c;
 	str[len] = '\0';
 	return (str);
+}
+
+int	str_is_only_space(char *str)
+{
+	size_t	i;
+
+	i = 0;
+	while (str[i])
+	{
+		if (str[i] != ' ')
+			return (0);
+		++i;
+	}
+	return (1);
 }


### PR DESCRIPTION
The problem was that immediately after filling `input` with `readline()`, we added `input` directly to the history without checking.

So I've added a condition that doesn't add `input` to the history if `input` is `NULL`, empty or if it's only made up of spaces.

In fact, I discovered while experimenting with Bash that it didn't add a space-only string to the history.