### PR TITLE
fix #50

### DIFF
--- a/exec/exec.h
+++ b/exec/exec.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 22:18:47 by lray              #+#    #+#             */
-/*   Updated: 2023/10/07 21:13:00 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/14 15:48:08 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,6 +14,7 @@
 # define EXEC_H
 
 # include <sys/wait.h>
+# include <sys/stat.h>
 
 int			exec(t_ctx *ctx);
 char		*get_cmd_path(char *cmd, t_grpvar *grpvar);

--- a/exec/get_cmd_path.c
+++ b/exec/get_cmd_path.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/19 17:04:59 by lray              #+#    #+#             */
-/*   Updated: 2023/10/07 16:09:39 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/14 15:49:16 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -108,6 +108,15 @@ static int	end_by_slash(char *path)
 
 static int	is_an_executable(char *path)
 {
+	struct stat	sb;
+
+	if (stat(path, &sb) == -1)
+	{
+		ft_puterror("Stat failed");
+		return (0);
+	}
+	if (S_ISDIR(sb.st_mode))
+		return (0);
 	if (access(path, (F_OK | X_OK)) == -1)
 		return (0);
 	return (1);


### PR DESCRIPTION
The bug came from the fact that I thought the `X_OK` flag in `access()` would definitely detect whether a path passed as a parameter was an executable file. In reality it checked if the path was an executable and a folder could have execute permissions.
So I thought the `is_an_executable()` function was detecting that "/" was not a valid executable, but it was.

To correct the problem, I added a step to the `is_an_executable()` function. Now I use the `stat()` function and the `S_ISDIR()` macro to detect if the path is a directory, if so it returns `0`.