### PR TITLE
Add heredoc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,7 @@ SRCS 		:= \
 	exec/make_argv.c \
 	exec/get_infd.c \
 	exec/get_outfd.c \
+	exec/make_heredoc.c \
 	signals/signals.c \
 	utils.c \
 	main.c

--- a/exec/exec.h
+++ b/exec/exec.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 22:18:47 by lray              #+#    #+#             */
-/*   Updated: 2023/10/14 15:48:08 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/23 15:54:36 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,5 +24,6 @@ int			open_file_wr(char *path);
 int			open_file_wra(char *path);
 int			get_infd(t_dyntree *root);
 int			get_outfd(t_dyntree *root);
+char		*make_heredoc(char *deli);
 
 #endif

--- a/exec/get_infd.c
+++ b/exec/get_infd.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/03 20:18:42 by lray              #+#    #+#             */
-/*   Updated: 2023/10/04 01:10:28 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/23 16:28:18 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,16 +14,26 @@
 
 int	get_infd(t_dyntree *root)
 {
-	int	fd;
+	int		fd;
 	size_t	i_child;
+	char	*filename;
 
+	filename = NULL;
 	fd = 0;
-	if (root->type == TK_REDIRECTION && root->value[0] == '<' && ft_strlen(root->value) == 1)
+	if (root->type == TK_REDIRECTION)
+	{
+		if (root->type == TK_REDIRECTION && ft_strncmp(root->value, "<<\0", 3) == 0)
+		{
+			filename = make_heredoc(root->children[0]->value);
+			free(root->children[0]->value);
+			root->children[0]->value = filename;
+		}
 		fd = open_file_rd(root->children[0]->value);
+	}
 	i_child = 0;
 	while (i_child < root->numChildren)
 	{
-		if (root->children[i_child]->type == TK_REDIRECTION && root->children[i_child]->value[0] == '<' && ft_strlen(root->children[i_child]->value) == 1)
+		if (root->children[i_child]->type == TK_REDIRECTION && (ft_strncmp(root->children[i_child]->value, "<\0", 2) == 0 || ft_strncmp(root->children[i_child]->value, "<<\0", 3) == 0))
 		{
 			if (fd > 2)
 				close(fd);

--- a/exec/make_heredoc.c
+++ b/exec/make_heredoc.c
@@ -1,0 +1,99 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   make_heredoc.c                                     :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/10/23 15:11:04 by lray              #+#    #+#             */
+/*   Updated: 2023/10/23 17:19:25 by lray             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../minishell.h"
+
+static char	*make_filename(void);
+static int	get_randnum(void);
+
+/*
+	TODO:
+		- Ajouter la gestion des signaux pour ctrl+C
+*/
+
+char	*make_heredoc(char *deli)
+{
+	char	*filename;
+	int		fd;
+	char	*input;
+
+	input = NULL;
+	filename = make_filename();
+	fd = open_file_wr(filename);
+	while (1)
+	{
+		input = readline("> ");
+		if (input == NULL)
+		{
+			ft_puterror("\nminishell: warning: here-document delimited by end-of-file");
+			free(input);
+			break ;
+		}
+		if (ft_strncmp(deli, input, ft_strlen(deli) + 1) == 0)
+		{
+			free(input);
+			break ;
+		}
+		write(fd, input, ft_strlen(input));
+		write(fd, "\n", 1);
+		free(input);
+	}
+	close(fd);
+	return (filename);
+}
+
+static char	*make_filename(void)
+{
+	char	*res;
+	int		rand;
+	char	*rand_str;
+
+	rand_str = NULL;
+	rand = get_randnum();
+	rand_str = ft_itoa(rand);
+	res = malloc(sizeof(char) * (ft_strlen(rand_str) + 15));
+	if (!res)
+	{
+		ft_puterror("Malloc failed");
+		return (NULL);
+	}
+	ft_strlcpy(res, "/tmp/minishell", 15);
+	ft_strlcat(res, rand_str, ft_strlen(rand_str) + 15);
+	free(rand_str);
+	return (res);
+}
+
+static int	get_randnum(void)
+{
+	int	res;
+	int	fd;
+
+	res = 0;
+	fd = open("/dev/urandom", O_RDONLY);
+	if (fd == -1)
+	{
+		perror("open");
+		return (0);
+	}
+	if (read(fd, &res, sizeof(res)) != sizeof(res))
+	{
+		perror("read");
+		return (0);
+	}
+	if (close(fd) == -1)
+	{
+		perror("close");
+		return (0);
+	}
+	res = ft_abs(res);
+	return (res);
+}

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 19:13:07 by lray              #+#    #+#             */
-/*   Updated: 2023/10/21 16:38:11 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/23 15:19:08 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,5 +63,7 @@ char	*add_char_to_string(char *str, char c);
 int		str_is_only_space(char *str);
 
 void	arr_show(char **arr);
+
+int		ft_abs(int n);
 
 #endif

--- a/utils.c
+++ b/utils.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 21:58:35 by lray              #+#    #+#             */
-/*   Updated: 2023/10/21 16:11:32 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/23 15:18:33 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -91,4 +91,11 @@ void	arr_show(char **arr)
 		while (arr[i])
 			printf("%s\n", arr[i++]);
 	}
+}
+
+int	ft_abs(int n)
+{
+	if (n < 0)
+		n *= -1;
+	return (n);
 }


### PR DESCRIPTION
Now that the commands are executed in real time, I've been able to add the heredoc operator.

To do this, I adapted the `get_infd()` function. Now, if the token value is `<<`, we call the `make_heredoc()` function, whose function is to generate a random file name, create it in `/tmp` and retrieve the user's keystroke and put it in the file until the user enters the delimiter. The function returns the path of the file created so that we can replace the value of the `TK_FILE` (the delimiter) with the path of the file and call `open_file_rd()` as if it were the `<` redirector.

For the moment, the signals are not functional. I've created an issue (#71) to be able to track this.