### PR TITLE
Add retourne code

### DIFF
--- a/builtins/exit.c
+++ b/builtins/exit.c
@@ -3,24 +3,23 @@
 /*                                                        :::      ::::::::   */
 /*   exit.c                                             :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: mflury <mflury@student.42lausanne.ch>      +#+  +:+       +#+        */
+/*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/10 18:12:24 by mflury            #+#    #+#             */
-/*   Updated: 2023/10/10 20:59:52 by mflury           ###   ########.fr       */
+/*   Updated: 2023/10/26 21:17:14 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-// note that "1" in exit() should be replaced by the global
-// error code modulo 256 when we implement it.
-
 int	builtin_exit(char **argv, t_ctx *ctx)
 {
 	(void)argv;
+	int	code;
 
+	code = ctx->ret_code;
 	clear_history();
 	ctx_free(ctx);
 	printf("exit\n");
-	exit (1 % 256);
+	exit(code);
 }

--- a/ctx/ctx.c
+++ b/ctx/ctx.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 20:30:19 by lray              #+#    #+#             */
-/*   Updated: 2023/10/23 18:50:43 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 18:07:35 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -34,6 +34,7 @@ t_ctx	*ctx_init(t_ctx *ctx, char **envp)
 		ctx->lstbltins = lstbuiltins_init(ctx->lstbltins);
 		if (!ctx->lstbltins)
 			return (NULL);
+		ctx->ret_code = 0;
 		set_sigmode(&ctx->sigset, SIGMODE_NORMAL);
 		return (ctx);
 	}
@@ -53,6 +54,8 @@ void	ctx_show(t_ctx *ctx)
 	printf("\n");
 	printf("= DYNTREE SHOW =\n");
 	dyntree_show(ctx->tree, 0);
+	printf("\n");
+	printf("Return code : %d\n", ctx->ret_code);
 	printf("\n");
 }
 

--- a/ctx/ctx.h
+++ b/ctx/ctx.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 20:24:50 by lray              #+#    #+#             */
-/*   Updated: 2023/10/23 18:38:51 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 18:06:24 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ typedef struct s_ctx
 	char					*input;
 	struct s_dyntklist		*tklist;
 	struct s_dyntree		*tree;
+	int						ret_code;
 }	t_ctx;
 
 t_ctx	*ctx_init(t_ctx *ctx, char **envp);

--- a/exec/exec.c
+++ b/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 22:19:41 by lray              #+#    #+#             */
-/*   Updated: 2023/10/26 18:17:58 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 21:16:25 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -102,6 +102,7 @@ static t_env	*set_env_cmd(t_env *env ,t_dyntree *root, t_ctx *ctx, int pipe_in, 
 	env->path = get_cmd_path(root->value, ctx->grpvar);
 	if (!env->path)
 	{
+		ctx->ret_code = 127;
 		ft_puterror("command not found");
 		env_free(env);
 		return (NULL);

--- a/exec/exec.c
+++ b/exec/exec.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 22:19:41 by lray              #+#    #+#             */
-/*   Updated: 2023/10/23 22:12:19 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 18:17:58 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -21,7 +21,7 @@ static t_env	*select_fd(t_env *env);
 static void		run_cmd(t_env *env, t_grpvar *grpvar);
 static void		run_builtins(t_env *env, t_ctx *ctx);
 static pid_t	*make_pids(pid_t *pids, int num_pids);
-static void		wait_all(pid_t *pids, int num_cmd);
+static void		wait_all(pid_t *pids, int num_cmd, t_ctx *ctx);
 static void		close_unused_pipes(int **pipes_list, int nbr_pipes, int pipe_in, int pipe_out);
 
 int	exec(t_ctx *ctx)
@@ -56,7 +56,7 @@ int	exec(t_ctx *ctx)
 			env_free(env);
 			++i_child;
 		}
-		wait_all(pids, ctx->tree->numChildren);
+		wait_all(pids, ctx->tree->numChildren, ctx);
 		free(pids);
 		pipes_list_free(pipes_list, (int)ctx->tree->numChildren -1);
 	}
@@ -70,7 +70,7 @@ int	exec(t_ctx *ctx)
 			return (0);
 		}
 		exec_env(ctx, env, &pids[0], NULL, 0);
-		wait_all(pids, 1);
+		wait_all(pids, 1, ctx);
 		env_free(env);
 		free(pids);
 	}
@@ -253,14 +253,18 @@ static pid_t *make_pids(pid_t *pids, int num_pids)
 	return (pids);
 }
 
-static void	wait_all(pid_t *pids, int num_cmd)
+static void	wait_all(pid_t *pids, int num_cmd, t_ctx *ctx)
 {
 	int	i;
+	int	status;
 
+	status = -1;
 	i = 0;
 	while (i < num_cmd)
 	{
-		waitpid(pids[i], NULL, 0);
+		waitpid(pids[i], &status, 0);
+		if (WIFEXITED(status))
+			ctx->ret_code = WEXITSTATUS(status);
 		++i;
 	}
 }

--- a/expand/expand.c
+++ b/expand/expand.c
@@ -6,13 +6,13 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/27 15:19:55 by lray              #+#    #+#             */
-/*   Updated: 2023/10/13 20:49:26 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 20:55:59 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
-static int	valide_tree(t_dyntree *root);
+static int	valide_tree(t_ctx *ctx, t_dyntree *root);
 static int	is_quote(char c);
 int	delete_quotes(t_dyntree *root);
 
@@ -20,16 +20,16 @@ int	expand(t_ctx *ctx)
 {
 	if (!ctx->tree || !ctx->grpvar)
 		return (0);
-	if (!replace_var(ctx->tree, ctx->grpvar))
+	if (!replace_var(ctx->tree, ctx))
 		return (0);
 	delete_quotes(ctx->tree);
-	if (!valide_tree(ctx->tree))
+	if (!valide_tree(ctx, ctx->tree))
 		return (0);
 	replace_builtins(ctx->tree, ctx);
 	return (1);
 }
 
-static int	valide_tree(t_dyntree *root)
+static int	valide_tree(t_ctx *ctx, t_dyntree *root)
 {
 	size_t	i;
 
@@ -39,6 +39,7 @@ static int	valide_tree(t_dyntree *root)
 	{
 		if (root->value[0] == '\0')
 		{
+			ctx->ret_code = 2;
 			ft_puterror("ambiguous redirect");
 			return (0);
 		}
@@ -47,6 +48,7 @@ static int	valide_tree(t_dyntree *root)
 	{
 		if (root->numChildren < 2)
 		{
+			ctx->ret_code = 2;
 			ft_puterror("ambiguous redirect");
 			return (0);
 		}
@@ -64,7 +66,7 @@ static int	valide_tree(t_dyntree *root)
 	i = 0;
 	while (i < root->numChildren)
 	{
-		if (!valide_tree(root->children[i++]))
+		if (!valide_tree(ctx, root->children[i++]))
 			return (0);
 	}
 	return (1);
@@ -76,7 +78,6 @@ int	delete_quotes(t_dyntree *root)
 	size_t	i_str;
 	char	quote;
 
-	// sa"lu'ca"lut
 	quote = 0;
 	if (root->type == TK_COMMAND || root->type == TK_ARGUMENT || root->type == TK_FILE)
 	{
@@ -104,9 +105,7 @@ int	delete_quotes(t_dyntree *root)
 	}
 	i_child = 0;
 	while (i_child < root->numChildren)
-	{
 		delete_quotes(root->children[i_child++]);
-	}
 	return (1);
 }
 

--- a/expand/replace_var.h
+++ b/expand/replace_var.h
@@ -6,12 +6,12 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/09/29 19:49:20 by lray              #+#    #+#             */
-/*   Updated: 2023/09/29 19:54:24 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 19:49:14 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #ifndef REPLACE_VAR_H
 # define REPLACE_H
 
-int	replace_var(t_dyntree *root, t_grpvar *grpvar);
+int	replace_var(t_dyntree *root, t_ctx *ctx);
 #endif

--- a/lexer/lexer.c
+++ b/lexer/lexer.c
@@ -6,14 +6,14 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/09 23:26:56 by lray              #+#    #+#             */
-/*   Updated: 2023/10/18 18:13:52 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 20:51:35 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
 
 static void	skip_space(char *input, int *i);
-static int	add_redirect(char *input, t_dyntklist *tklist, int *i);
+static int	add_redirect(t_ctx *ctx, t_dyntklist *tklist, int *i);
 static int	add_to_tklist(char *input, int *i, t_dyntklist *tklist, int tktype);
 static char	*value_init(char *value);
 static char	*value_add(char *value, size_t *value_len, char c);
@@ -44,7 +44,7 @@ int	lexer(t_ctx *ctx)
 			}
 			else
 			{
-				if (add_redirect(ctx->input, ctx->tklist, &i) == 0)
+				if (add_redirect(ctx, ctx->tklist, &i) == 0)
 					return (0);
 				skip_space(ctx->input, &i);
 				if (add_to_tklist(ctx->input, &i, ctx->tklist, TK_FILE) == 0)
@@ -74,21 +74,23 @@ static void	skip_space(char *input, int *i)
 		(*i)++;
 }
 
-static int	add_redirect(char *input, t_dyntklist *tklist, int *i)
+static int	add_redirect(t_ctx *ctx, t_dyntklist *tklist, int *i)
 {
 	char *value;
 
-	if (input[(*i) + 1] == '\0')
+	if (ctx->input[(*i) + 1] == '\0')
 	{
+		ctx->ret_code = 2;
 		ft_puterror("Syntax error");
 		return (0);
 	}
-	else if (input[*i] != input[(*i) + 1] && is_redirect(input[(*i) + 1]))
+	else if (ctx->input[*i] != ctx->input[(*i) + 1] && is_redirect(ctx->input[(*i) + 1]))
 	{
+		ctx->ret_code = 2;
 		ft_puterror("Syntax error");
 		return (0);
 	}
-	else if (input[*i] == input[(*i) + 1])
+	else if (ctx->input[*i] == ctx->input[(*i) + 1])
 	{
 		value = malloc(sizeof(char) * 3);
 		if (value == NULL)
@@ -96,8 +98,8 @@ static int	add_redirect(char *input, t_dyntklist *tklist, int *i)
 			ft_puterror("Malloc failed");
 			return (0);
 		}
-		value[0] = input[*i];
-		value[1] = input[*i];
+		value[0] = ctx->input[*i];
+		value[1] = ctx->input[*i];
 		value[2] = '\0';
 		dyntklist_add(tklist, TK_REDIRECTION, value);
 		free(value);
@@ -112,7 +114,7 @@ static int	add_redirect(char *input, t_dyntklist *tklist, int *i)
 			ft_puterror("Malloc failed");
 			return (0);
 		}
-		value[0] = input[*i];
+		value[0] = ctx->input[*i];
 		value[1] = '\0';
 		dyntklist_add(tklist, TK_REDIRECTION, value);
 		free(value);

--- a/main.c
+++ b/main.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 19:08:50 by lray              #+#    #+#             */
-/*   Updated: 2023/10/24 16:34:16 by lray             ###   ########.fr       */
+/*   Updated: 2023/10/26 20:52:10 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -24,10 +24,15 @@ int	main(int argc, char **argv, char **envp)
 	ctx = ctx_init(ctx, envp);
 	while (1)
 	{
+		ctx->ret_code = 0;
 		ctx_free_line(ctx);
 		ctx->input = prompt_get();
 		if (ctx->input == NULL)
+		{
+			ctx->ret_code = 0;
 			builtin_exit(NULL, ctx);
+
+		}
 		else if (ctx->input[0] == '\0')
 			continue ;
 		if (lexer(ctx) == 0)


### PR DESCRIPTION
This PR adds support for `$?`.

The first thing I did was to modify `replace_var()` to replace the variable with the return code if a `$?` is detected.

Next, I added a field to the `ctx` structure in order to retain the return code.

I've also added the right error codes for problems with `lexer` or `expand`.