### PR TITLE
init PWD, OLDPWD and HOME

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ NAME		:= minishell
 
 SRCS 		:= \
 	ctx/ctx.c \
+	ctx/ctx_utils.c \
 	vars/var.c \
 	vars/lstvar.c \
 	vars/lstvar_utils.c \

--- a/ctx/ctx.c
+++ b/ctx/ctx.c
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 20:30:19 by lray              #+#    #+#             */
-/*   Updated: 2023/10/31 20:28:34 by lray             ###   ########.fr       */
+/*   Updated: 2023/11/01 12:14:42 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -31,6 +31,7 @@ t_ctx	*ctx_init(t_ctx *ctx, char **envp)
 		ctx->tklist = NULL;
 		ctx->tree = NULL;
 		ctx->grpvar = grpvar_init(envp);
+		var_set_init_value(ctx);
 		ctx->lstbltins = lstbuiltins_init(ctx->lstbltins);
 		if (!ctx->lstbltins)
 			return (NULL);

--- a/ctx/ctx.h
+++ b/ctx/ctx.h
@@ -6,7 +6,7 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/10/07 20:24:50 by lray              #+#    #+#             */
-/*   Updated: 2023/10/28 23:01:06 by lray             ###   ########.fr       */
+/*   Updated: 2023/11/01 12:13:47 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,5 +33,7 @@ t_ctx	*ctx_init(t_ctx *ctx, char **envp);
 void	ctx_show(t_ctx *ctx);
 void	ctx_free(t_ctx *ctx);
 void	ctx_free_line(t_ctx *ctx);
+
+int		var_set_init_value(t_ctx *ctx);
 
 #endif

--- a/ctx/ctx_utils.c
+++ b/ctx/ctx_utils.c
@@ -1,0 +1,32 @@
+/* ************************************************************************** */
+/*                                                                            */
+/*                                                        :::      ::::::::   */
+/*   ctx_utils.c                                        :+:      :+:    :+:   */
+/*                                                    +:+ +:+         +:+     */
+/*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
+/*                                                +#+#+#+#+#+   +#+           */
+/*   Created: 2023/11/01 12:08:25 by lray              #+#    #+#             */
+/*   Updated: 2023/11/01 12:24:15 by lray             ###   ########.fr       */
+/*                                                                            */
+/* ************************************************************************** */
+
+#include "../minishell.h"
+
+static void	set_home(t_grpvar *grpvar);
+
+int	var_set_init_value(t_ctx *ctx)
+{
+	grpvar_add(ctx->grpvar, GRPVAR_GLOBAL, "PWD", NULL);
+	grpvar_add(ctx->grpvar, GRPVAR_GLOBAL, "OLDPWD", NULL);
+	set_home(ctx->grpvar);
+	return (1);
+}
+
+static void	set_home(t_grpvar *grpvar)
+{
+	int	pos;
+
+	pos = grpvar_has(grpvar, GRPVAR_GLOBAL, "HOME");
+	if (pos == -1 || grpvar->global->array[pos]->value[0] == '\0')
+		grpvar_add(grpvar, GRPVAR_GLOBAL, "HOME", "/");
+}

--- a/main.c
+++ b/main.c
@@ -6,11 +6,13 @@
 /*   By: lray <lray@student.42lausanne.ch >         +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/08/06 19:08:50 by lray              #+#    #+#             */
-/*   Updated: 2023/10/31 21:19:10 by lray             ###   ########.fr       */
+/*   Updated: 2023/11/01 12:28:05 by lray             ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "minishell.h"
+
+static t_ctx	*app_init(t_ctx *ctx, char **envp);
 
 int	g_in_heredoc = 0;
 
@@ -20,7 +22,7 @@ int	main(int argc, char **argv, char **envp)
 
 	(void) argc, (void) argv;
 	ctx = NULL;
-	ctx = ctx_init(ctx, envp);
+	ctx = app_init(ctx, envp);
 	while (1)
 	{
 		ctx_free_line(ctx);
@@ -41,4 +43,10 @@ int	main(int argc, char **argv, char **envp)
 		exec(ctx);
 	}
 	return (0);
+}
+
+static t_ctx	*app_init(t_ctx *ctx, char **envp)
+{
+	ctx = ctx_init(ctx, envp);
+	return (ctx);
 }


### PR DESCRIPTION
In this PR, I've added the init for the `PWD`, `OLDPWD`, `HOME` environment variables. 

The `PWD` and `OLDPWD` variables are set to NULL in all cases. For `HOME`, if the variable does not exist or if it is set to NULL, it is set to `/`.

This PR prepares the initialization of `minishell` or it will place us in the user's home directory when it is launched.